### PR TITLE
feat: chat; server-side proxy for chat to keep backend key secret (HLA-202)

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -7,7 +7,7 @@ export function Chat() {
   const [open, setOpen] = useState(false);
 
   const { messages, sendMessage, isLoading } = useChat({
-    connection: fetchServerSentEvents(`${import.meta.env.VITE_SERVER_URL}/marriott/chat`),
+    connection: fetchServerSentEvents("/api/marriott/chat"),
   });
 
   const handleSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as ApiAnalyticsRouteImport } from './routes/api/analytics'
 import { Route as pageslandingIndexRouteImport } from './routes/(pages)/(landing)/index'
 import { Route as pagesCategoryIndexRouteImport } from './routes/(pages)/$category/index'
+import { Route as ApiMarriottChatRouteImport } from './routes/api/marriott.chat'
 import { Route as pagesCategorySlugIndexRouteImport } from './routes/(pages)/$category/$slug/index'
 
 const ApiAnalyticsRoute = ApiAnalyticsRouteImport.update({
@@ -29,6 +30,11 @@ const pagesCategoryIndexRoute = pagesCategoryIndexRouteImport.update({
   path: '/$category/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMarriottChatRoute = ApiMarriottChatRouteImport.update({
+  id: '/api/marriott/chat',
+  path: '/api/marriott/chat',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const pagesCategorySlugIndexRoute = pagesCategorySlugIndexRouteImport.update({
   id: '/(pages)/$category/$slug/',
   path: '/$category/$slug/',
@@ -37,12 +43,14 @@ const pagesCategorySlugIndexRoute = pagesCategorySlugIndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/api/analytics': typeof ApiAnalyticsRoute
+  '/api/marriott/chat': typeof ApiMarriottChatRoute
   '/$category/': typeof pagesCategoryIndexRoute
   '/': typeof pageslandingIndexRoute
   '/$category/$slug/': typeof pagesCategorySlugIndexRoute
 }
 export interface FileRoutesByTo {
   '/api/analytics': typeof ApiAnalyticsRoute
+  '/api/marriott/chat': typeof ApiMarriottChatRoute
   '/$category': typeof pagesCategoryIndexRoute
   '/': typeof pageslandingIndexRoute
   '/$category/$slug': typeof pagesCategorySlugIndexRoute
@@ -50,18 +58,30 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/api/analytics': typeof ApiAnalyticsRoute
+  '/api/marriott/chat': typeof ApiMarriottChatRoute
   '/(pages)/$category/': typeof pagesCategoryIndexRoute
   '/(pages)/(landing)/': typeof pageslandingIndexRoute
   '/(pages)/$category/$slug/': typeof pagesCategorySlugIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/api/analytics' | '/$category/' | '/' | '/$category/$slug/'
+  fullPaths:
+    | '/api/analytics'
+    | '/api/marriott/chat'
+    | '/$category/'
+    | '/'
+    | '/$category/$slug/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/api/analytics' | '/$category' | '/' | '/$category/$slug'
+  to:
+    | '/api/analytics'
+    | '/api/marriott/chat'
+    | '/$category'
+    | '/'
+    | '/$category/$slug'
   id:
     | '__root__'
     | '/api/analytics'
+    | '/api/marriott/chat'
     | '/(pages)/$category/'
     | '/(pages)/(landing)/'
     | '/(pages)/$category/$slug/'
@@ -69,6 +89,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   ApiAnalyticsRoute: typeof ApiAnalyticsRoute
+  ApiMarriottChatRoute: typeof ApiMarriottChatRoute
   pagesCategoryIndexRoute: typeof pagesCategoryIndexRoute
   pageslandingIndexRoute: typeof pageslandingIndexRoute
   pagesCategorySlugIndexRoute: typeof pagesCategorySlugIndexRoute
@@ -97,6 +118,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof pagesCategoryIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/marriott/chat': {
+      id: '/api/marriott/chat'
+      path: '/api/marriott/chat'
+      fullPath: '/api/marriott/chat'
+      preLoaderRoute: typeof ApiMarriottChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/(pages)/$category/$slug/': {
       id: '/(pages)/$category/$slug/'
       path: '/$category/$slug'
@@ -109,6 +137,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   ApiAnalyticsRoute: ApiAnalyticsRoute,
+  ApiMarriottChatRoute: ApiMarriottChatRoute,
   pagesCategoryIndexRoute: pagesCategoryIndexRoute,
   pageslandingIndexRoute: pageslandingIndexRoute,
   pagesCategorySlugIndexRoute: pagesCategorySlugIndexRoute,

--- a/src/routes/api/marriott.chat.ts
+++ b/src/routes/api/marriott.chat.ts
@@ -1,0 +1,33 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { env } from "cloudflare:workers";
+
+// Same-origin proxy for the chat SSE stream. The backend gates /marriott/* on x-api-key; keeping
+// the key here (a Worker secret, never a VITE_ build constant) is the only way it stays off the client.
+export const Route = createFileRoute("/api/marriott/chat")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const apiKey = (env as unknown as { MARRIOTT_API_KEY?: string }).MARRIOTT_API_KEY;
+        const headers: Record<string, string> = {
+          "Content-Type": request.headers.get("content-type") ?? "application/json",
+          Accept: "text/event-stream",
+        };
+        if (apiKey) headers["x-api-key"] = apiKey;
+
+        const upstream = await fetch(`${import.meta.env.VITE_SERVER_URL}/marriott/chat`, {
+          method: "POST",
+          headers,
+          body: await request.text(),
+        });
+
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: {
+            "Content-Type": upstream.headers.get("content-type") ?? "text/event-stream",
+            "Cache-Control": "no-cache",
+          },
+        });
+      },
+    },
+  },
+});


### PR DESCRIPTION
The backend now gates /api/v1/marriott/* on an `x-api-key` header (backend HLA-202). Chat was called **directly from the browser**, so a `VITE_`-prefixed key would ship in the public bundle — no protection. This routes chat through a same-origin server proxy that injects the key from a Worker secret.

- New `src/routes/api/marriott.chat.ts`: same-origin `POST /api/marriott/chat` → backend `/marriott/chat`, attaches `x-api-key` from `cloudflare:workers` `env.MARRIOTT_API_KEY` (Worker secret, **not** `VITE_`), streams the SSE response through.
- `Chat.tsx` points at the same-origin proxy instead of the backend directly.
- Verified: `MARRIOTT_API_KEY` does **not** appear in the client bundle; proxy compiles into the server bundle; build green.

Deploy: set `wrangler secret put MARRIOTT_API_KEY` on **this** worker (same value as the backend secret) before/with enabling the backend guard. Until the secret is set the header is simply omitted (dev + pre-rollout safe).

Notes (pre-existing, not touched): repo-wide prettier drift (25 files), a broken `test` script (Cloudflare-vite-plugin startup incompatibility), and `Chat` is imported-but-unused in `__root.tsx` — flagging that last one since it means the widget may not be mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)